### PR TITLE
Add CMake build system using clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.16)
+# Force use of clang before project() so CMake configures with the correct compiler
+find_program(CLANG_BIN clang REQUIRED)
+set(CMAKE_C_COMPILER ${CLANG_BIN} CACHE STRING "C compiler" FORCE)
+
+project(taskd C)
+
+if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "Clang is required to build taskd")
+endif()
+
+if(CMAKE_C_COMPILER_VERSION VERSION_LESS "19")
+    message(FATAL_ERROR "Clang 19 or newer is required; found ${CMAKE_C_COMPILER_VERSION}")
+endif()
+
+# Ensure all git submodules are pulled
+execute_process(
+    COMMAND git submodule update --init --recursive
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE GIT_SUBMOD_RESULT
+)
+if(NOT GIT_SUBMOD_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to update git submodules")
+endif()
+
+# Build submodules when available
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/cJSON/CMakeLists.txt)
+    add_subdirectory(external/cJSON)
+endif()
+
+add_executable(taskd taskd.c)
+if(TARGET cjson)
+    target_link_libraries(taskd PRIVATE cjson)
+endif()
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ This daemon is designed for **high-performance parallelization** across isolated
 
 ---
 
+## 🔨 Building
+
+This project uses **CMake** and expects a recent `clang` compiler. The
+configuration step automatically fetches all git submodules.
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+`clang` version 19 or newer is required; configuration will fail if an
+older compiler is detected.
+
+---
+
 ## 🔧 Integration
 
 ### 1. Host Side: `extended_firecracker_parallel.py`


### PR DESCRIPTION
## Summary
- add a new `CMakeLists.txt` that pulls submodules and enforces clang >=19
- document build instructions in the README

## Testing
- `cmake .. && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68430419e3c88322b401f842f8af2204