### PR TITLE
Fix cJSON header path for cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,5 +31,6 @@ endif()
 add_executable(taskd taskd.c)
 if(TARGET cjson)
     target_link_libraries(taskd PRIVATE cjson)
+    target_include_directories(taskd PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/external/cJSON)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ This daemon is designed for **high-performance parallelization** across isolated
 ## 🔨 Building
 
 This project uses **CMake** and expects a recent `clang` compiler. The
-configuration step automatically fetches all git submodules.
+configuration step automatically fetches all git submodules, including the
+embedded [cJSON](https://github.com/DaveGamble/cJSON) library used for parsing
+and generating JSON.
 
 ```bash
 mkdir build && cd build


### PR DESCRIPTION
## Summary
- expose cJSON include directory in `CMakeLists.txt`
- mention bundled cJSON dependency in README

## Testing
- `PATH=/tmp/clang19:$PATH cmake ..`
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_68430734518483229c32b59565a77adc