### PR TITLE
Add hashing, logic, and directory state ops

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -51,6 +51,14 @@ register indices. File system instructions (create, copy, move, etc.) use these
 registers for their parameters and store success (non-zero) or result pointers in
 a destination register.
 
+Additional opcodes provide utility functions:
+
+- `SM_OP_FS_HASH` – compute an xxHash64 of the file at `path`.
+- `SM_OP_FS_LIST` – list directory entries separated by newlines.
+- `SM_OP_EQ` – compare two registers for equality.
+- `SM_OP_NOT` – logical negation of a register value.
+- `SM_OP_AND` / `SM_OP_OR` – logical conjunction/disjunction of two registers.
+
 ## Example recipe
 
 Below is a minimal recipe that creates an empty file `/tmp/hello.txt`.

--- a/protocol.h
+++ b/protocol.h
@@ -131,6 +131,12 @@ static inline bool opcode_from_string(const char *s, sm_opcode *out) {
       {"SM_OP_FS_WRITE", SM_OP_FS_WRITE},
       {"SM_OP_FS_READ", SM_OP_FS_READ},
       {"SM_OP_FS_UNPACK", SM_OP_FS_UNPACK},
+      {"SM_OP_FS_HASH", SM_OP_FS_HASH},
+      {"SM_OP_FS_LIST", SM_OP_FS_LIST},
+      {"SM_OP_EQ", SM_OP_EQ},
+      {"SM_OP_NOT", SM_OP_NOT},
+      {"SM_OP_AND", SM_OP_AND},
+      {"SM_OP_OR", SM_OP_OR},
       {"SM_OP_RETURN", SM_OP_RETURN},
   };
   for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); ++i) {
@@ -299,6 +305,105 @@ static inline sm_instr *proto_parse_recipe(const char *json) {
       }
       d->tar_path = tar_path->valueint;
       d->dest = dest->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_FS_HASH: {
+      sm_fs_hash *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *path = cJSON_GetObjectItemCaseSensitive(data, "path");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(path)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->path = path->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_FS_LIST: {
+      sm_fs_list *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *path = cJSON_GetObjectItemCaseSensitive(data, "path");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(path)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->path = path->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_EQ: {
+      sm_eq *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *lhs = cJSON_GetObjectItemCaseSensitive(data, "lhs");
+      cJSON *rhs = cJSON_GetObjectItemCaseSensitive(data, "rhs");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(lhs) ||
+          !cJSON_IsNumber(rhs)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->lhs = lhs->valueint;
+      d->rhs = rhs->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_NOT: {
+      sm_not *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *src = cJSON_GetObjectItemCaseSensitive(data, "src");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(src)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->src = src->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_AND: {
+      sm_and *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *lhs = cJSON_GetObjectItemCaseSensitive(data, "lhs");
+      cJSON *rhs = cJSON_GetObjectItemCaseSensitive(data, "rhs");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(lhs) ||
+          !cJSON_IsNumber(rhs)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->lhs = lhs->valueint;
+      d->rhs = rhs->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_OR: {
+      sm_or *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *lhs = cJSON_GetObjectItemCaseSensitive(data, "lhs");
+      cJSON *rhs = cJSON_GetObjectItemCaseSensitive(data, "rhs");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(lhs) ||
+          !cJSON_IsNumber(rhs)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->lhs = lhs->valueint;
+      d->rhs = rhs->valueint;
       ins->data = d;
       break;
     }

--- a/state_machine.c
+++ b/state_machine.c
@@ -123,6 +123,60 @@ void sm_execute(sm_instr *head, sm_vm *vm) {
         fs_unpack(t, d);
       break;
     }
+    case SM_OP_FS_HASH: {
+      sm_fs_hash *a = (sm_fs_hash *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->path))
+        break;
+      const char *p = (const char *)vm->regs[a->path];
+      char *h = p ? fs_hash(p) : NULL;
+      vm->regs[a->dest] = h;
+      break;
+    }
+    case SM_OP_FS_LIST: {
+      sm_fs_list *a = (sm_fs_list *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->path))
+        break;
+      const char *p = (const char *)vm->regs[a->path];
+      char *list = p ? fs_list_dir(p) : NULL;
+      vm->regs[a->dest] = list;
+      break;
+    }
+    case SM_OP_EQ: {
+      sm_eq *a = (sm_eq *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->lhs) || !reg_valid(a->rhs))
+        break;
+      uintptr_t l = (uintptr_t)vm->regs[a->lhs];
+      uintptr_t r = (uintptr_t)vm->regs[a->rhs];
+      bool eq = l == r;
+      vm->regs[a->dest] = (void *)(uintptr_t)eq;
+      break;
+    }
+    case SM_OP_NOT: {
+      sm_not *a = (sm_not *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->src))
+        break;
+      bool v = (uintptr_t)vm->regs[a->src] != 0;
+      vm->regs[a->dest] = (void *)(uintptr_t)(!v);
+      break;
+    }
+    case SM_OP_AND: {
+      sm_and *a = (sm_and *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->lhs) || !reg_valid(a->rhs))
+        break;
+      bool l = (uintptr_t)vm->regs[a->lhs] != 0;
+      bool r = (uintptr_t)vm->regs[a->rhs] != 0;
+      vm->regs[a->dest] = (void *)(uintptr_t)(l && r);
+      break;
+    }
+    case SM_OP_OR: {
+      sm_or *a = (sm_or *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->lhs) || !reg_valid(a->rhs))
+        break;
+      bool l = (uintptr_t)vm->regs[a->lhs] != 0;
+      bool r = (uintptr_t)vm->regs[a->rhs] != 0;
+      vm->regs[a->dest] = (void *)(uintptr_t)(l || r);
+      break;
+    }
     case SM_OP_RETURN: {
       sm_return *a = (sm_return *)cur->data;
       int val = a ? a->value : 0;

--- a/state_machine.h
+++ b/state_machine.h
@@ -19,6 +19,12 @@ typedef enum {
   SM_OP_FS_WRITE,
   SM_OP_FS_READ,
   SM_OP_FS_UNPACK,
+  SM_OP_FS_HASH,
+  SM_OP_FS_LIST,
+  SM_OP_EQ,
+  SM_OP_NOT,
+  SM_OP_AND,
+  SM_OP_OR,
   SM_OP_RETURN,
 } sm_opcode;
 
@@ -73,6 +79,39 @@ typedef struct {
   int tar_path;
   int dest;
 } sm_fs_unpack;
+
+typedef struct {
+  int dest;
+  int path;
+} sm_fs_hash;
+
+typedef struct {
+  int dest;
+  int path;
+} sm_fs_list;
+
+typedef struct {
+  int dest;
+  int lhs;
+  int rhs;
+} sm_eq;
+
+typedef struct {
+  int dest;
+  int src;
+} sm_not;
+
+typedef struct {
+  int dest;
+  int lhs;
+  int rhs;
+} sm_and;
+
+typedef struct {
+  int dest;
+  int lhs;
+  int rhs;
+} sm_or;
 
 typedef struct {
   int value;


### PR DESCRIPTION
## Summary
- extend state machine with file hashing, directory listing and logic ops
- parse new opcodes in protocol
- implement helper functions using xxHash
- document additional operations

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684879e1290c832298d9797839de267f