### PR TITLE
Add state machine index and random ops

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -58,6 +58,10 @@ Additional opcodes provide utility functions:
 - `SM_OP_EQ` – compare two registers for equality.
 - `SM_OP_NOT` – logical negation of a register value.
 - `SM_OP_AND` / `SM_OP_OR` – logical conjunction/disjunction of two registers.
+- `SM_OP_INDEX_SELECT` – extract the item at `index` from a newline separated
+  string in `list`.
+- `SM_OP_RANDOM_RANGE` – store a pseudo-random integer between `min` and `max`
+  (inclusive) in `dest`.
 
 ## Example recipe
 

--- a/fs_utils.h
+++ b/fs_utils.h
@@ -292,6 +292,41 @@ static inline const char *rand_choice(const char **options, size_t count) {
   return options[idx];
 }
 
+static inline char *list_index(const char *list, size_t idx) {
+  if (!list)
+    return NULL;
+  const char *start = list;
+  while (idx > 0 && *start) {
+    const char *nl = strchr(start, '\n');
+    if (!nl)
+      return NULL;
+    start = nl + 1;
+    --idx;
+  }
+  if (*start == '\0')
+    return NULL;
+  const char *end = strchr(start, '\n');
+  size_t len = end ? (size_t)(end - start) : strlen(start);
+  char *out = malloc(len + 1);
+  if (!out)
+    return NULL;
+  memcpy(out, start, len);
+  out[len] = '\0';
+  return out;
+}
+
+static inline long rand_range(long min, long max) {
+  if (max < min) {
+    long tmp = min;
+    min = max;
+    max = tmp;
+  }
+  long diff = max - min + 1;
+  if (diff <= 0)
+    return min;
+  return (long)(rand() % diff) + min;
+}
+
 static inline void seed_apply(unsigned int seed) { srand(seed); }
 
 #ifdef __cplusplus

--- a/protocol.h
+++ b/protocol.h
@@ -137,6 +137,8 @@ static inline bool opcode_from_string(const char *s, sm_opcode *out) {
       {"SM_OP_NOT", SM_OP_NOT},
       {"SM_OP_AND", SM_OP_AND},
       {"SM_OP_OR", SM_OP_OR},
+      {"SM_OP_INDEX_SELECT", SM_OP_INDEX_SELECT},
+      {"SM_OP_RANDOM_RANGE", SM_OP_RANDOM_RANGE},
       {"SM_OP_RETURN", SM_OP_RETURN},
   };
   for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); ++i) {
@@ -404,6 +406,42 @@ static inline sm_instr *proto_parse_recipe(const char *json) {
       d->dest = dest->valueint;
       d->lhs = lhs->valueint;
       d->rhs = rhs->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_INDEX_SELECT: {
+      sm_index_select *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *list = cJSON_GetObjectItemCaseSensitive(data, "list");
+      cJSON *index = cJSON_GetObjectItemCaseSensitive(data, "index");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(list) ||
+          !cJSON_IsNumber(index)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->list = list->valueint;
+      d->index = index->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_RANDOM_RANGE: {
+      sm_random_range *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *min = cJSON_GetObjectItemCaseSensitive(data, "min");
+      cJSON *max = cJSON_GetObjectItemCaseSensitive(data, "max");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(min) ||
+          !cJSON_IsNumber(max)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->min = min->valueint;
+      d->max = max->valueint;
       ins->data = d;
       break;
     }

--- a/state_machine.c
+++ b/state_machine.c
@@ -177,6 +177,30 @@ void sm_execute(sm_instr *head, sm_vm *vm) {
       vm->regs[a->dest] = (void *)(uintptr_t)(l || r);
       break;
     }
+    case SM_OP_INDEX_SELECT: {
+      sm_index_select *a = (sm_index_select *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->list) ||
+          !reg_valid(a->index))
+        break;
+      const char *list = (const char *)vm->regs[a->list];
+      size_t idx = (size_t)(uintptr_t)vm->regs[a->index];
+      char *out = NULL;
+      if (list) {
+        out = list_index(list, idx);
+      }
+      vm->regs[a->dest] = out;
+      break;
+    }
+    case SM_OP_RANDOM_RANGE: {
+      sm_random_range *a = (sm_random_range *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->min) || !reg_valid(a->max))
+        break;
+      long min = (long)(uintptr_t)vm->regs[a->min];
+      long max = (long)(uintptr_t)vm->regs[a->max];
+      long val = rand_range(min, max);
+      vm->regs[a->dest] = (void *)(uintptr_t)val;
+      break;
+    }
     case SM_OP_RETURN: {
       sm_return *a = (sm_return *)cur->data;
       int val = a ? a->value : 0;

--- a/state_machine.h
+++ b/state_machine.h
@@ -25,6 +25,8 @@ typedef enum {
   SM_OP_NOT,
   SM_OP_AND,
   SM_OP_OR,
+  SM_OP_INDEX_SELECT,
+  SM_OP_RANDOM_RANGE,
   SM_OP_RETURN,
 } sm_opcode;
 
@@ -112,6 +114,18 @@ typedef struct {
   int lhs;
   int rhs;
 } sm_or;
+
+typedef struct {
+  int dest;
+  int list;
+  int index;
+} sm_index_select;
+
+typedef struct {
+  int dest;
+  int min;
+  int max;
+} sm_random_range;
 
 typedef struct {
   int value;


### PR DESCRIPTION
## Summary
- implement `list_index()` and `rand_range()` helpers
- add `SM_OP_INDEX_SELECT` and `SM_OP_RANDOM_RANGE`
- extend recipe parser and executor with new opcodes
- document new operations in `PROTOCOL.md`

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68487db641088322a0078afe62e5f295