### PR TITLE
Implement path manipulation opcodes

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -62,6 +62,12 @@ Additional opcodes provide utility functions:
   string in `list`.
 - `SM_OP_RANDOM_RANGE` – store a pseudo-random integer between `min` and `max`
   (inclusive) in `dest`.
+- `SM_OP_PATH_JOIN` – join `base` and `name` with a slash and store the new
+  path in `dest`.
+- `SM_OP_RANDOM_WALK` – starting from `root`, walk `depth` random directory
+  levels and store the resulting path in `dest`.
+- `SM_OP_DIR_CONTAINS` – set `dest` to non-zero if directory `a` is fully
+  contained within directory `b`.
 
 ## Example recipe
 

--- a/protocol.h
+++ b/protocol.h
@@ -139,6 +139,9 @@ static inline bool opcode_from_string(const char *s, sm_opcode *out) {
       {"SM_OP_OR", SM_OP_OR},
       {"SM_OP_INDEX_SELECT", SM_OP_INDEX_SELECT},
       {"SM_OP_RANDOM_RANGE", SM_OP_RANDOM_RANGE},
+      {"SM_OP_PATH_JOIN", SM_OP_PATH_JOIN},
+      {"SM_OP_RANDOM_WALK", SM_OP_RANDOM_WALK},
+      {"SM_OP_DIR_CONTAINS", SM_OP_DIR_CONTAINS},
       {"SM_OP_RETURN", SM_OP_RETURN},
   };
   for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); ++i) {
@@ -442,6 +445,59 @@ static inline sm_instr *proto_parse_recipe(const char *json) {
       d->dest = dest->valueint;
       d->min = min->valueint;
       d->max = max->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_PATH_JOIN: {
+      sm_path_join *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *base = cJSON_GetObjectItemCaseSensitive(data, "base");
+      cJSON *name = cJSON_GetObjectItemCaseSensitive(data, "name");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(base) ||
+          !cJSON_IsNumber(name)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->base = base->valueint;
+      d->name = name->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_RANDOM_WALK: {
+      sm_random_walk *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *root = cJSON_GetObjectItemCaseSensitive(data, "root");
+      cJSON *depth = cJSON_GetObjectItemCaseSensitive(data, "depth");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(root) ||
+          !cJSON_IsNumber(depth)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->root = root->valueint;
+      d->depth = depth->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_DIR_CONTAINS: {
+      sm_dir_contains *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *a = cJSON_GetObjectItemCaseSensitive(data, "a");
+      cJSON *b = cJSON_GetObjectItemCaseSensitive(data, "b");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(a) || !cJSON_IsNumber(b)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->dir_a = a->valueint;
+      d->dir_b = b->valueint;
       ins->data = d;
       break;
     }

--- a/state_machine.c
+++ b/state_machine.c
@@ -201,6 +201,39 @@ void sm_execute(sm_instr *head, sm_vm *vm) {
       vm->regs[a->dest] = (void *)(uintptr_t)val;
       break;
     }
+    case SM_OP_PATH_JOIN: {
+      sm_path_join *a = (sm_path_join *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->base) ||
+          !reg_valid(a->name))
+        break;
+      const char *base = (const char *)vm->regs[a->base];
+      const char *name = (const char *)vm->regs[a->name];
+      char *out = (base && name) ? path_join(base, name) : NULL;
+      vm->regs[a->dest] = out;
+      break;
+    }
+    case SM_OP_RANDOM_WALK: {
+      sm_random_walk *a = (sm_random_walk *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->root) ||
+          !reg_valid(a->depth))
+        break;
+      const char *root = (const char *)vm->regs[a->root];
+      int depth = (int)(uintptr_t)vm->regs[a->depth];
+      char *out = root ? fs_random_walk(root, depth) : NULL;
+      vm->regs[a->dest] = out;
+      break;
+    }
+    case SM_OP_DIR_CONTAINS: {
+      sm_dir_contains *a = (sm_dir_contains *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->dir_a) ||
+          !reg_valid(a->dir_b))
+        break;
+      const char *ap = (const char *)vm->regs[a->dir_a];
+      const char *bp = (const char *)vm->regs[a->dir_b];
+      bool ok = (ap && bp) ? fs_dir_contains(ap, bp) : false;
+      vm->regs[a->dest] = (void *)(uintptr_t)ok;
+      break;
+    }
     case SM_OP_RETURN: {
       sm_return *a = (sm_return *)cur->data;
       int val = a ? a->value : 0;

--- a/state_machine.h
+++ b/state_machine.h
@@ -27,6 +27,9 @@ typedef enum {
   SM_OP_OR,
   SM_OP_INDEX_SELECT,
   SM_OP_RANDOM_RANGE,
+  SM_OP_PATH_JOIN,
+  SM_OP_RANDOM_WALK,
+  SM_OP_DIR_CONTAINS,
   SM_OP_RETURN,
 } sm_opcode;
 
@@ -126,6 +129,24 @@ typedef struct {
   int min;
   int max;
 } sm_random_range;
+
+typedef struct {
+  int dest;
+  int base;
+  int name;
+} sm_path_join;
+
+typedef struct {
+  int dest;
+  int root;
+  int depth;
+} sm_random_walk;
+
+typedef struct {
+  int dest;
+  int dir_a;
+  int dir_b;
+} sm_dir_contains;
 
 typedef struct {
   int value;


### PR DESCRIPTION
## Summary
- extend state machine with path join, random walk and directory subset checks
- implement helpers in fs_utils
- update protocol mapper and parser
- document new opcodes

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68487f58f2a88322bda2e60f25d06665