### PR TITLE
Enable state machine generated protocol reporting

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -68,6 +68,13 @@ Additional opcodes provide utility functions:
   levels and store the resulting path in `dest`.
 - `SM_OP_DIR_CONTAINS` – set `dest` to non-zero if directory `a` is fully
   contained within directory `b`.
+- `SM_OP_REPORT` – send a protocol message back to the host containing the
+  contents of the specified registers as a JSON array.
+
+`SM_OP_REPORT` requires a `regs` field listing which register indices should be
+included in the outbound message. When executed, the daemon builds a JSON object
+`{"values": [ ... ]}` and sends it over the active vsock connection before
+continuing with the recipe.
 
 ## Example recipe
 

--- a/state_machine.h
+++ b/state_machine.h
@@ -4,6 +4,8 @@
 #include <pthread.h>
 #include <stdbool.h>
 
+#define SM_REG_COUNT 8
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,6 +32,7 @@ typedef enum {
   SM_OP_PATH_JOIN,
   SM_OP_RANDOM_WALK,
   SM_OP_DIR_CONTAINS,
+  SM_OP_REPORT,
   SM_OP_RETURN,
 } sm_opcode;
 
@@ -149,6 +152,11 @@ typedef struct {
 } sm_dir_contains;
 
 typedef struct {
+  int count;
+  int regs[SM_REG_COUNT];
+} sm_report;
+
+typedef struct {
   int value;
 } sm_return;
 
@@ -159,6 +167,8 @@ void sm_thread_stop(sm_ctx *ctx);
 void sm_submit(sm_ctx *ctx, sm_instr *chain);
 sm_reg sm_get_reg(sm_ctx *ctx, int idx);
 void sm_wait(sm_ctx *ctx, int *value);
+typedef void (*sm_report_cb)(const char *json, void *user);
+void sm_set_report_cb(sm_ctx *ctx, sm_report_cb cb, void *user);
 
 /* Existing executor for direct use */
 typedef struct sm_vm sm_vm;


### PR DESCRIPTION
## Summary
- add new opcode `SM_OP_REPORT` and supporting struct
- allow state machine to send JSON messages back to the host
- expose `sm_set_report_cb` for configuring the reporting callback
- extend protocol parser to understand `SM_OP_REPORT`
- document reporting capability in `PROTOCOL.md`

## Testing
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684886035e5083228508631dff620bc3