### PR TITLE
Add shell execution opcode

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -56,6 +56,8 @@ Additional opcodes provide utility functions:
 
 - `SM_OP_FS_HASH` – compute an xxHash64 of the file at `path`.
 - `SM_OP_FS_LIST` – list directory entries separated by newlines.
+- `SM_OP_SHELL` – execute the command string in register `cmd` and store its
+  output in `dest`.
 - `SM_OP_EQ` – compare two registers for equality.
 - `SM_OP_NOT` – logical negation of a register value.
 - `SM_OP_AND` / `SM_OP_OR` – logical conjunction/disjunction of two registers.

--- a/fs_utils.h
+++ b/fs_utils.h
@@ -334,6 +334,37 @@ static inline char *path_join(const char *base, const char *name) {
   return out;
 }
 
+static inline char *fs_exec(const char *cmd) {
+  if (!cmd)
+    return NULL;
+  FILE *p = popen(cmd, "r");
+  if (!p)
+    return NULL;
+  size_t cap = 256, len = 0;
+  char *buf = malloc(cap);
+  if (!buf) {
+    pclose(p);
+    return NULL;
+  }
+  int c;
+  while ((c = fgetc(p)) != EOF) {
+    if (len + 1 >= cap) {
+      cap *= 2;
+      char *tmp = realloc(buf, cap);
+      if (!tmp) {
+        free(buf);
+        pclose(p);
+        return NULL;
+      }
+      buf = tmp;
+    }
+    buf[len++] = (char)c;
+  }
+  buf[len] = '\0';
+  pclose(p);
+  return buf;
+}
+
 static inline char *fs_random_walk(const char *root, int depth) {
   if (!root || depth < 0)
     return NULL;

--- a/protocol.h
+++ b/protocol.h
@@ -134,6 +134,7 @@ static inline bool opcode_from_string(const char *s, sm_opcode *out) {
       {"SM_OP_FS_UNPACK", SM_OP_FS_UNPACK},
       {"SM_OP_FS_HASH", SM_OP_FS_HASH},
       {"SM_OP_FS_LIST", SM_OP_FS_LIST},
+      {"SM_OP_SHELL", SM_OP_SHELL},
       {"SM_OP_EQ", SM_OP_EQ},
       {"SM_OP_NOT", SM_OP_NOT},
       {"SM_OP_AND", SM_OP_AND},
@@ -348,6 +349,21 @@ static inline sm_instr *proto_parse_recipe(const char *json) {
       }
       d->dest = dest->valueint;
       d->path = path->valueint;
+      ins->data = d;
+      break;
+    }
+    case SM_OP_SHELL: {
+      sm_shell *d = malloc(sizeof(*d));
+      if (!d)
+        break;
+      cJSON *dest = cJSON_GetObjectItemCaseSensitive(data, "dest");
+      cJSON *cmd = cJSON_GetObjectItemCaseSensitive(data, "cmd");
+      if (!cJSON_IsNumber(dest) || !cJSON_IsNumber(cmd)) {
+        free(d);
+        break;
+      }
+      d->dest = dest->valueint;
+      d->cmd = cmd->valueint;
       ins->data = d;
       break;
     }

--- a/state_machine.c
+++ b/state_machine.c
@@ -147,6 +147,15 @@ void sm_execute(sm_instr *head, sm_vm *vm) {
       vm->regs[a->dest] = list;
       break;
     }
+    case SM_OP_SHELL: {
+      sm_shell *a = (sm_shell *)cur->data;
+      if (!a || !reg_valid(a->dest) || !reg_valid(a->cmd))
+        break;
+      const char *c = (const char *)vm->regs[a->cmd];
+      char *out = c ? fs_exec(c) : NULL;
+      vm->regs[a->dest] = out;
+      break;
+    }
     case SM_OP_EQ: {
       sm_eq *a = (sm_eq *)cur->data;
       if (!a || !reg_valid(a->dest) || !reg_valid(a->lhs) || !reg_valid(a->rhs))

--- a/state_machine.h
+++ b/state_machine.h
@@ -23,6 +23,7 @@ typedef enum {
   SM_OP_FS_UNPACK,
   SM_OP_FS_HASH,
   SM_OP_FS_LIST,
+  SM_OP_SHELL,
   SM_OP_EQ,
   SM_OP_NOT,
   SM_OP_AND,
@@ -98,6 +99,11 @@ typedef struct {
   int dest;
   int path;
 } sm_fs_list;
+
+typedef struct {
+  int dest;
+  int cmd;
+} sm_shell;
 
 typedef struct {
   int dest;


### PR DESCRIPTION
## Summary
- allow state machine to run shell commands
- implement `SM_OP_SHELL` in the protocol and VM
- document the new opcode

## Testing
- `git submodule update --init --recursive`
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684daa9f97848322b50444456d635b38