### PR TITLE
Improve state machine error handling

### DIFF
--- a/fs_utils.h
+++ b/fs_utils.h
@@ -58,6 +58,8 @@ static int fs_unlink_cb(const char *fpath, const struct stat *sb, int typeflag,
 }
 
 static inline bool fs_delete(const char *path) {
+  if (!path || strcmp(path, "/") == 0 || path[0] == '\0')
+    return false;
   struct stat st;
   if (lstat(path, &st) != 0)
     return false;

--- a/sm_test.c
+++ b/sm_test.c
@@ -35,7 +35,11 @@ int main(void) {
   }
 
   sm_set_report_cb(ctx, report_cb, NULL);
-  sm_submit(ctx, recipe);
+  if (!sm_submit(ctx, recipe)) {
+    fprintf(stderr, "failed to submit job\n");
+    sm_thread_stop(ctx);
+    return 1;
+  }
   int ret = 0;
   sm_wait(ctx, &ret);
   sm_thread_stop(ctx);

--- a/state_machine.h
+++ b/state_machine.h
@@ -13,6 +13,13 @@ extern "C" {
 typedef void *sm_reg;
 
 typedef enum {
+  SM_ERR_NONE = 0,
+  SM_ERR_BAD_REG = 1,
+  SM_ERR_BAD_OP = 2,
+  SM_ERR_INTERNAL = 3,
+} sm_error;
+
+typedef enum {
   SM_OP_LOAD_CONST,
   SM_OP_FS_CREATE,
   SM_OP_FS_DELETE,
@@ -175,7 +182,7 @@ typedef struct sm_ctx sm_ctx;
 
 sm_ctx *sm_thread_start(void);
 void sm_thread_stop(sm_ctx *ctx);
-void sm_submit(sm_ctx *ctx, sm_instr *chain);
+bool sm_submit(sm_ctx *ctx, sm_instr *chain);
 sm_reg sm_get_reg(sm_ctx *ctx, int idx);
 void sm_wait(sm_ctx *ctx, int *value);
 typedef void (*sm_report_cb)(const char *json, void *user);
@@ -183,7 +190,7 @@ void sm_set_report_cb(sm_ctx *ctx, sm_report_cb cb, void *user);
 
 /* Existing executor for direct use */
 typedef struct sm_vm sm_vm;
-void sm_execute(sm_instr *head, sm_vm *vm);
+int sm_execute(sm_instr *head, sm_vm *vm);
 
 #ifdef __cplusplus
 }

--- a/taskd.c
+++ b/taskd.c
@@ -166,7 +166,12 @@ int main(int argc, char *argv[]) {
       sm_instr *recipe = proto_parse_recipe(msg);
       if (recipe) {
         sm_set_report_cb(g_sm_ctx, report_fd_cb, &client_fd);
-        sm_submit(g_sm_ctx, recipe);
+        if (!sm_submit(g_sm_ctx, recipe)) {
+          free(msg);
+          sm_set_report_cb(g_sm_ctx, NULL, NULL);
+          close(client_fd);
+          continue;
+        }
         free(msg);
         int ret = 0;
         sm_wait(g_sm_ctx, &ret);


### PR DESCRIPTION
## Summary
- add `sm_error` enum to represent execution errors
- have `sm_execute` return an error code
- make `sm_submit` report allocation failure
- propagate execution return values and submission errors
- guard against dangerous paths in `fs_delete`

## Testing
- `git submodule update --init --recursive`
- `cmake ..`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684db38d5bd0832288c1858c72cb185c